### PR TITLE
ISSUE-404: Sync with 2.4 - Product Feed index process unknown error

### DIFF
--- a/app/code/Magento/CatalogDataExporter/Test/Integration/AbstractProductTestHelper.php
+++ b/app/code/Magento/CatalogDataExporter/Test/Integration/AbstractProductTestHelper.php
@@ -16,7 +16,7 @@ use Magento\Catalog\Model\Product\Visibility;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Serialize\Serializer\GzcompressDecorator;
 use Magento\Framework\UrlInterface;
 use Magento\Indexer\Model\Indexer;
 use Magento\Store\Model\StoreManagerInterface;
@@ -53,7 +53,7 @@ abstract class AbstractProductTestHelper extends \PHPUnit\Framework\TestCase
     protected $connection;
 
     /**
-     * @var Json
+     * @var GzcompressDecorator
      */
     protected $jsonSerializer;
 
@@ -104,7 +104,7 @@ abstract class AbstractProductTestHelper extends \PHPUnit\Framework\TestCase
         $this->storeManager = Bootstrap::getObjectManager()->create(StoreManagerInterface::class);
         $this->taxClassSource = Bootstrap::getObjectManager()->create(TaxClassSource::class);
 
-        $this->jsonSerializer = Bootstrap::getObjectManager()->create(Json::class);
+        $this->jsonSerializer = Bootstrap::getObjectManager()->create(GzcompressDecorator::class);
     }
 
     /**

--- a/app/code/Magento/CatalogDataExporter/etc/db_schema.xml
+++ b/app/code/Magento/CatalogDataExporter/etc/db_schema.xml
@@ -29,7 +29,7 @@
             comment="Store view code"
         />
         <column
-            xsi:type="mediumtext"
+            xsi:type="blob"
             name="feed_data"
             nullable="false"
             comment="Feed Data"
@@ -72,7 +72,7 @@
                 length="64"
                 comment="Store view code"
         />
-        <column xsi:type="mediumtext"
+        <column xsi:type="blob"
                 name="feed_data"
                 nullable="false"
                 comment="Feed Data"
@@ -111,7 +111,7 @@
                 comment="Store view code"
         />
         <column
-            xsi:type="mediumtext"
+            xsi:type="blob"
             name="feed_data"
             nullable="false"
             comment="Feed Data"

--- a/app/code/Magento/CatalogDataExporter/etc/di.xml
+++ b/app/code/Magento/CatalogDataExporter/etc/di.xml
@@ -435,6 +435,12 @@
         </arguments>
     </virtualType>
 
+    <type name="Magento\DataExporter\Model\Feed">
+        <arguments>
+            <argument name="serializer" xsi:type="object">Magento\Framework\Serialize\Serializer\GzcompressDecorator</argument>
+        </arguments>
+    </type>
+
     <type name="Magento\DataExporter\Model\FeedPool">
         <arguments>
             <argument name="classMap" xsi:type="array">

--- a/app/code/Magento/DataExporter/etc/di.xml
+++ b/app/code/Magento/DataExporter/etc/di.xml
@@ -33,6 +33,13 @@
             <argument name="data" xsi:type="object">Magento\DataExporter\Config\Data</argument>
         </arguments>
     </type>
+
+    <type name="Magento\DataExporter\Model\Indexer\DataSerializer">
+        <arguments>
+            <argument name="serializer" xsi:type="object">Magento\Framework\Serialize\Serializer\GzcompressDecorator</argument>
+        </arguments>
+    </type>
+
     <preference for="Magento\DataExporter\Config\ConfigInterface" type="Magento\DataExporter\Config\Config" />
 
     <preference for="Magento\DataExporter\Model\Indexer\FeedIndexerCallbackInterface"

--- a/lib/internal/Magento/Framework/Serialize/Serialize/GzcompressDecorator.php
+++ b/lib/internal/Magento/Framework/Serialize/Serialize/GzcompressDecorator.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Serialize\Serializer;
+
+use Magento\Framework\Serialize\SerializerInterface;
+
+/**
+ * Compress data.
+ */
+class GzcompressDecorator implements SerializerInterface
+{
+    /**
+     * Json serializer.
+     *
+     * @var Json
+     */
+    private $serializer;
+
+    /**
+     * @param Json $serializer
+     */
+    public function __construct(Json $serializer)
+    {
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function serialize($data)
+    {
+        return gzcompress($this->serializer->serialize($data), 9);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unserialize($string)
+    {
+        return $this->serializer->unserialize(gzuncompress($string));
+    }
+}


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/catalog-storefront#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/catalog-storefront#404


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Code Review Checklist (*)

See detailed [checklist](https://github.com/magento/catalog-storefront/blob/develop/dev/docs/projectAgreements/Code-Review-checklist.md)

- [ ] Story AC is completed
- [ ] proposed changes correspond to [Magento Technical Vision](https://devdocs.magento.com/guides/v2.2/coding-standards/technical-guidelines.html)
- [ ] new or changed code is covered with web-api/integration tests (if applicable)
  - expected results in test verified with data from fixture
- [ ] no backward incompatible changes
- [ ] Export API (et_schema.xml) and SF API schemas (proto schema) are reflected in the codebase
  - prerequisite: story branch created with all needed generated classes according to proposes schema-changes
  - DTO classes do not contain any manual changes (Magento\CatalogExportApi\*, Magento\CatalogStorefrontApi\*)
- [ ] Class usage: magento/catalog-storefront repo don't use directly classes from magento/saas-export repo and vise-verse
  - Check composer.json dependencies
- [ ] Legacy code is deleted
  - Any Data Providers present in Connector part  (Magento\CatalogStorefrontConnector, Magento\*Extractor modules)
  - And Data Providers from Export API (magento/saas-export repo) that is not relevant anymore
  - Any DTO for Export API/SF API which does not reflect current schema: et_schema, proto schema
  - Any “mapper” on Message Broker (between Export API and SF API)
    - if mapper still needed, verify fields used in mapping, remove not relevant fields


