### PR TITLE
price-formation-changes

### DIFF
--- a/app/code/Magento/CatalogPriceDataExporter/Model/Indexer/PriceBuilder.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Indexer/PriceBuilder.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Indexer;
+
+use Magento\CatalogDataExporter\Model\Provider\Product\ProductOptions\CustomizableEnteredOptionValueUid;
+use Magento\CatalogDataExporter\Model\Provider\Product\ProductOptions\CustomizableSelectedOptionValueUid;
+use Magento\CatalogDataExporter\Model\Provider\Product\ProductOptions\DownloadableLinksOptionUid;
+
+/**
+ * Class responsible for indexing product price build event data
+ */
+class PriceBuilder
+{
+    /**
+     * @var CustomizableEnteredOptionValueUid
+     */
+    private $optionValueUid;
+
+    /**
+     * @var DownloadableLinksOptionUid
+     */
+    private $downloadableLinksOptionUid;
+
+    /**
+     * @param CustomizableEnteredOptionValueUid $optionValueUid
+     * @param DownloadableLinksOptionUid $downloadableLinksOptionUid
+     */
+    public function __construct(
+        CustomizableEnteredOptionValueUid $optionValueUid,
+        DownloadableLinksOptionUid $downloadableLinksOptionUid
+    ) {
+        $this->optionValueUid = $optionValueUid;
+        $this->downloadableLinksOptionUid = $downloadableLinksOptionUid;
+    }
+
+    /**
+     * Build event data for product custom option price
+     *
+     * @param array $data
+     *
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function buildCustomOptionPriceEventData(array $data): array
+    {
+        $id = $this->optionValueUid->resolve([CustomizableEnteredOptionValueUid::OPTION_ID => $data['option_id']]);
+
+        return [
+            'id' => $id,
+            'value' => $data['price'],
+            'price_type' => $data['price_type'],
+        ];
+    }
+
+    /**
+     * Build complex product event data.
+     *
+     * @param string $parentId
+     * @param string $variationId
+     * @param string $linkType
+     *
+     * @return array
+     */
+    public function buildComplexProductEventData(string $parentId, string $variationId, string $linkType): array
+    {
+        return [
+            'id' => $parentId,
+            'variation_id' => $variationId,
+            'price_type' => $linkType,
+        ];
+    }
+
+    /**
+     * Build custom option type price event data
+     *
+     * @param array $data
+     *
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function buildCustomOptionTypePriceEventData(array $data): array
+    {
+        $id = $this->optionValueUid->resolve(
+            [
+                CustomizableSelectedOptionValueUid::OPTION_ID => $data['option_id'],
+                CustomizableSelectedOptionValueUid::OPTION_VALUE_ID => $data['option_type_id'],
+            ]
+        );
+
+        return [
+            'id' => $id,
+            'value' => $data['price'],
+            'price_type' => $data['price_type'],
+        ];
+    }
+
+    /**
+     * Build downloadable link price event data.
+     *
+     * @param string $entityId
+     * @param string $value
+     *
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function buildDownloadableLinkPriceEventData(string $entityId, string $value): array
+    {
+        $id = $this->downloadableLinksOptionUid->resolve([DownloadableLinksOptionUid::OPTION_ID => $entityId]);
+        return [
+            'id' => $id,
+            'value' => $value,
+        ];
+    }
+
+    /**
+     * Build event data.
+     *
+     * @param string $entityId
+     * @param string $attributeCode
+     * @param string|null $attributeValue
+     *
+     * @return array
+     */
+    public function buildProductPriceEventData(string $entityId, string $attributeCode, ?string $attributeValue): array
+    {
+        return [
+            'id' => $entityId,
+            'attribute_code' => $attributeCode,
+            'value' => $attributeValue,
+        ];
+    }
+
+    /**
+     * Build event data.
+     *
+     * @param string $entityId
+     * @param string $qty
+     * @param string|null $priceType
+     * @param string|null $value
+     * @return array
+     */
+    public function buildTierPriceEventData(string $entityId, string $qty, ?string $priceType, ?string $value): array
+    {
+        return [
+            'id' => $entityId,
+            'attribute_code' => 'tier_price',
+            'qty' => $qty,
+            'price_type' => $priceType,
+            'value' => $value,
+        ];
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Indexer/PriceBuilder.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Indexer/PriceBuilder.php
@@ -122,7 +122,7 @@ class PriceBuilder
     }
 
     /**
-     * Build event data.
+     * Build product price event data.
      *
      * @param string $entityId
      * @param string $attributeCode
@@ -140,7 +140,7 @@ class PriceBuilder
     }
 
     /**
-     * Build event data.
+     * Build tier price event data.
      *
      * @param string $entityId
      * @param string $qty

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/ComplexProductEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/ComplexProductEvent.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\FullReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\ComplexProductLink;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing complex product variation change events for full indexation
+ */
+class ComplexProductEvent implements FullReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var ComplexProductLink
+     */
+    private $complexProductLink;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var string
+     */
+    private $linkType;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param ComplexProductLink $complexProductLink
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param StoreManagerInterface $storeManager
+     * @param PriceBuilder $priceBuilder
+     * @param LoggerInterface $logger
+     * @param string $linkType
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        ComplexProductLink $complexProductLink,
+        EventKeyGenerator $eventKeyGenerator,
+        StoreManagerInterface $storeManager,
+        PriceBuilder $priceBuilder,
+        LoggerInterface $logger,
+        string $linkType
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->complexProductLink = $complexProductLink;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->storeManager = $storeManager;
+        $this->priceBuilder = $priceBuilder;
+        $this->logger = $logger;
+        $this->linkType = $linkType;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(): \Generator
+    {
+        $continue = true;
+        $lastKnownId = 0;
+        try {
+            while ($continue === true) {
+                $result = [];
+                $select = $this->complexProductLink->getQuery(null, null, (int)$lastKnownId, self::BATCH_SIZE);
+                $cursor = $this->resourceConnection->getConnection()->query($select);
+                while ($row = $cursor->fetch()) {
+                    $result[$row['parent_id']][] = $row['variation_id'];
+                    $lastKnownId = $row['link_id'];
+                }
+                if (empty($result)) {
+                    $continue = false;
+                } else {
+                    yield $this->getEventsData($result);
+                }
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve complex product link data for full sync.');
+        }
+    }
+
+    /**
+     * Retrieve prices event data
+     *
+     * @param array $data
+     *
+     * @return array
+     *
+     * @throws LocalizedException
+     */
+    private function getEventsData(array $data): array
+    {
+        $events = [];
+        $websiteId = (string)$this->storeManager->getWebsite(WebsiteInterface::ADMIN_CODE)->getWebsiteId();
+        $key = $this->eventKeyGenerator->generate(self::EVENT_VARIATION_CHANGED, $websiteId, null);
+        $linkType = $this->linkType;
+        foreach ($data as $parentId => $children) {
+            foreach ($children as $variationId) {
+                $events[$key][] = $this->priceBuilder->buildComplexProductEventData(
+                    (string)$parentId,
+                    $variationId,
+                    $linkType
+                );
+            }
+        }
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/CustomOptionPriceEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/CustomOptionPriceEvent.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\FullReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\CustomOptionPrice;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing custom option price events for full indexation
+ */
+class CustomOptionPriceEvent implements FullReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var CustomOptionPrice
+     */
+    private $customOptionPrice;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param CustomOptionPrice $customOptionPrice
+     * @param StoreManagerInterface $storeManager
+     * @param PriceBuilder $priceBuilder
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        CustomOptionPrice $customOptionPrice,
+        StoreManagerInterface $storeManager,
+        PriceBuilder $priceBuilder,
+        EventKeyGenerator $eventKeyGenerator,
+        LoggerInterface $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->customOptionPrice = $customOptionPrice;
+        $this->storeManager = $storeManager;
+        $this->priceBuilder = $priceBuilder;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(): \Generator
+    {
+        try {
+            foreach ($this->storeManager->getStores(true) as $store) {
+                $storeId = (int)$store->getId();
+                $continue = true;
+                $lastKnownId = 0;
+                while ($continue === true) {
+                    $result = [];
+                    $select = $this->customOptionPrice->getQuery([], $storeId, $lastKnownId, self::BATCH_SIZE);
+                    $cursor = $this->resourceConnection->getConnection()->query($select);
+                    while ($row = $cursor->fetch()) {
+                        $result[$row['option_id']] = [
+                            'option_id' => $row['option_id'],
+                            'price' => $row['price'],
+                            'price_type' => $row['price_type'],
+                        ];
+                    }
+                    if (empty($result)) {
+                        $continue = false;
+                    } else {
+                        yield $this->getEventData($result, $storeId);
+                        $lastKnownId = array_key_last($result);
+                    }
+                }
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve product custom options price data.');
+        }
+    }
+
+    /**
+     * Retrieve prices event data
+     *
+     * @param array $resultData
+     * @param int $storeId
+     *
+     * @return array
+     *
+     * @throws NoSuchEntityException
+     */
+    private function getEventData(array $resultData, int $storeId): array
+    {
+        $events = [];
+        $websiteId = (string)$this->storeManager->getStore($storeId)->getWebsiteId();
+        $key = $this->eventKeyGenerator->generate(self::EVENT_CUSTOM_OPTION_PRICE_CHANGED, $websiteId, null);
+        foreach ($resultData as $priceData) {
+            $events[$key][] = $this->priceBuilder->buildCustomOptionPriceEventData($priceData);
+        }
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/CustomOptionTypePriceEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/CustomOptionTypePriceEvent.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\FullReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\CustomOptionTypePrice;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing custom selectable option price events for full indexation
+ */
+class CustomOptionTypePriceEvent implements FullReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var CustomOptionTypePrice
+     */
+    private $customOptionTypePrice;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param CustomOptionTypePrice $customOptionTypePrice
+     * @param StoreManagerInterface $storeManager
+     * @param PriceBuilder $priceBuilder
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        CustomOptionTypePrice $customOptionTypePrice,
+        StoreManagerInterface $storeManager,
+        PriceBuilder $priceBuilder,
+        EventKeyGenerator $eventKeyGenerator,
+        LoggerInterface $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->customOptionTypePrice = $customOptionTypePrice;
+        $this->storeManager = $storeManager;
+        $this->priceBuilder = $priceBuilder;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(): \Generator
+    {
+        try {
+            foreach ($this->storeManager->getStores(true) as $store) {
+                $storeId = (int)$store->getId();
+                $continue = true;
+                $lastKnownId = 0;
+                while ($continue === true) {
+                    $select = $this->customOptionTypePrice->getQuery(
+                        [],
+                        $storeId,
+                        $lastKnownId,
+                        self::BATCH_SIZE
+                    );
+                    $cursor = $this->resourceConnection->getConnection()->query($select);
+                    $result = [];
+                    while ($row = $cursor->fetch()) {
+                        $result[$row['option_type_id']] = [
+                            'option_id' => $row['option_id'],
+                            'option_type_id' => $row['option_type_id'],
+                            'price' => $row['price'],
+                            'price_type' => $row['price_type'],
+                        ];
+                    }
+                    if (empty($result)) {
+                        $continue = false;
+                    } else {
+                        yield $this->getEventsData($result, $storeId);
+                        $lastKnownId = array_key_last($result);
+                    }
+                }
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve product custom option types price data for full sync.');
+        }
+    }
+
+    /**
+     * Retrieve prices event data
+     *
+     * @param array $resultData
+     * @param int $storeId
+     *
+     * @return array
+     *
+     * @throws NoSuchEntityException
+     */
+    private function getEventsData(array $resultData, int $storeId): array
+    {
+        $events = [];
+        $websiteId = (string)$this->storeManager->getStore($storeId)->getWebsiteId();
+        $key = $this->eventKeyGenerator->generate(
+            self::EVENT_CUSTOM_OPTION_TYPE_PRICE_CHANGED,
+            $websiteId,
+            null
+        );
+        foreach ($resultData as $priceData) {
+            $events[$key][] = $this->priceBuilder->buildCustomOptionTypePriceEventData($priceData);
+        }
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/DownloadableLinkPriceEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/DownloadableLinkPriceEvent.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\FullReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\DownloadableLinkPrice;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing downloadable product link price events for full indexation
+ */
+class DownloadableLinkPriceEvent implements FullReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var DownloadableLinkPrice
+     */
+    private $downloadableLinkPrice;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param DownloadableLinkPrice $downloadableLinkPrice
+     * @param StoreManagerInterface $storeManager
+     * @param PriceBuilder $priceBuilder
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        DownloadableLinkPrice $downloadableLinkPrice,
+        StoreManagerInterface $storeManager,
+        PriceBuilder $priceBuilder,
+        EventKeyGenerator $eventKeyGenerator,
+        LoggerInterface $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->downloadableLinkPrice = $downloadableLinkPrice;
+        $this->storeManager = $storeManager;
+        $this->priceBuilder = $priceBuilder;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(): \Generator
+    {
+        try {
+            foreach ($this->storeManager->getStores(true) as $store) {
+                $storeId = (int)$store->getId();
+                $continue = true;
+                $lastKnownId = 0;
+                while ($continue === true) {
+                    $result = [];
+                    $select = $this->downloadableLinkPrice->getQuery([], $storeId, (int)$lastKnownId, self::BATCH_SIZE);
+                    $cursor = $this->resourceConnection->getConnection()->query($select);
+                    while ($row = $cursor->fetch()) {
+                        $result[$row['entity_id']] = $row['value'];
+                        $lastKnownId = $row['link_id'];
+                    }
+                    if (empty($result)) {
+                        $continue = false;
+                    } else {
+                        yield $this->getEventsData($result, $storeId);
+                    }
+                }
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve downloadable link price data for full sync.');
+        }
+    }
+
+    /**
+     * Retrieve prices event data
+     *
+     * @param array $actualData
+     * @param int $storeId
+     *
+     * @return array
+     *
+     * @throws NoSuchEntityException
+     */
+    private function getEventsData(array $actualData, int $storeId): array
+    {
+        $events = [];
+        $websiteId = (string)$this->storeManager->getStore($storeId)->getWebsiteId();
+        $key = $this->eventKeyGenerator->generate(
+            self::EVENT_DOWNLOADABLE_LINK_PRICE_CHANGED,
+            $websiteId,
+            null
+        );
+        foreach ($actualData as $entityId => $value) {
+            $events[$key][] = $this->priceBuilder->buildDownloadableLinkPriceEventData((string)$entityId, $value);
+        }
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/ProductPriceEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/ProductPriceEvent.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\FullReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\ProductPrice;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing product price / special price events for full indexation
+ */
+class ProductPriceEvent implements FullReindexPriceProviderInterface
+{
+    /**
+     * Product price eav attributes
+     */
+    public const PRICE_ATTRIBUTES = ['price', 'special_price'];
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var ProductPrice
+     */
+    private $productPrice;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param ProductPrice $productPrice
+     * @param StoreManagerInterface $storeManager
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        ProductPrice $productPrice,
+        StoreManagerInterface $storeManager,
+        EventKeyGenerator $eventKeyGenerator,
+        PriceBuilder $priceBuilder,
+        LoggerInterface $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->productPrice = $productPrice;
+        $this->storeManager = $storeManager;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->priceBuilder = $priceBuilder;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(): \Generator
+    {
+        try {
+            foreach ($this->storeManager->getStores(true) as $store) {
+                $storeId = (int)$store->getId();
+                $continue = true;
+                $lastKnownId = 0;
+                while ($continue === true) {
+                    $select = $this->productPrice->getQuery(
+                        [],
+                        $storeId,
+                        self::PRICE_ATTRIBUTES,
+                        $lastKnownId,
+                        self::BATCH_SIZE
+                    );
+                    $cursor = $this->resourceConnection->getConnection()->query($select);
+                    $result = [];
+                    while ($row = $cursor->fetch()) {
+                        $result[$row['entity_id']][$row['attribute_code']] = $row['value'];
+                    }
+                    if (empty($result)) {
+                        $continue = false;
+                    } else {
+                        yield $this->getEventsData($result, $storeId);
+                        $lastKnownId = array_key_last($result);
+                    }
+                }
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve product price data for full sync.');
+        }
+    }
+
+    /**
+     * Retrieve prices event data.
+     *
+     * @param array $data
+     * @param int $storeId
+     *
+     * @return array
+     *
+     * @throws NoSuchEntityException
+     */
+    private function getEventsData(array $data, int $storeId): array
+    {
+        $events = [];
+        $websiteId = (string)$this->storeManager->getStore($storeId)->getWebsiteId();
+        $key = $this->eventKeyGenerator->generate(self::EVENT_PRICE_CHANGED, $websiteId, null);
+        foreach ($data as $entityId => $priceData) {
+            foreach ($priceData as $attributeCode => $value) {
+                $events[$key][] = $this->priceBuilder->buildProductPriceEventData(
+                    (string)$entityId,
+                    $attributeCode,
+                    $value
+                );
+            }
+        }
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/TierPriceEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/FullReindex/TierPriceEvent.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\FullReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\TierPrice;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing product tier prices events for full indexation
+ */
+class TierPriceEvent implements FullReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var TierPrice
+     */
+    private $tierPrice;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param TierPrice $tierPrice
+     * @param StoreManagerInterface $storeManager
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param PriceBuilder $priceBuilder
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        TierPrice $tierPrice,
+        StoreManagerInterface $storeManager,
+        EventKeyGenerator $eventKeyGenerator,
+        PriceBuilder $priceBuilder,
+        LoggerInterface $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->tierPrice = $tierPrice;
+        $this->storeManager = $storeManager;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->priceBuilder = $priceBuilder;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(): \Generator
+    {
+        try {
+            foreach ($this->storeManager->getStores(true) as $store) {
+                $storeId = (int)$store->getId();
+                $continue = true;
+                $lastKnownId = 0;
+                while ($continue === true) {
+                    $result = [];
+                    $select = $this->tierPrice->getQuery([], $storeId, $lastKnownId, self::BATCH_SIZE);
+                    $cursor = $this->resourceConnection->getConnection()->query($select);
+                    while ($row = $cursor->fetch()) {
+                        $result[$row['entity_id']][$row['customer_group_id']][$row['qty']] = $row;
+                    }
+                    if (empty($result)) {
+                        $continue = false;
+                    } else {
+                        yield $this->getEventsData($result, $storeId);
+                        $lastKnownId = array_key_last($result);
+                    }
+                }
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve product tier price data for full sync.');
+        }
+    }
+
+    /**
+     * Build query arguments
+     *
+     * @param array $indexData
+     *
+     * @return array
+     */
+    private function buildQueryArguments(): array
+    {
+        $queryArguments = [];
+        foreach ($this->storeManager->getStores(true) as $store) {
+            $queryArguments[$store->getId()] = [];
+        }
+        return $queryArguments;
+    }
+
+    /**
+     * Form prices event data.
+     *
+     * @param array $actualData
+     * @param int $storeId
+     * @return array
+     *
+     * @throws NoSuchEntityException
+     */
+    private function getEventsData(array $actualData, int $storeId): array
+    {
+        $events = [];
+        $websiteId = (string)$this->storeManager->getStore($storeId)->getWebsiteId();
+        foreach ($actualData as $entityId => $entityData) {
+            foreach ($entityData as $customerGroup => $groupData) {
+                foreach ($groupData as $qty => $priceData) {
+                    $eventType = $qty > 1 ? self::EVENT_TIER_PRICE_CHANGED : self::EVENT_PRICE_CHANGED;
+                    $key = $this->eventKeyGenerator->generate(
+                        $eventType,
+                        $websiteId,
+                        (string)$customerGroup
+                    );
+                    $events[$key][] = $this->priceBuilder->buildTierPriceEventData(
+                        (string)$entityId,
+                        $qty,
+                        $priceData['group_price_type'],
+                        $priceData['value']
+                    );
+                }
+            }
+        }
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/ComplexProductEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/ComplexProductEvent.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\PartialReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\ComplexProductLink;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing complex product variation change events
+ */
+class ComplexProductEvent implements PartialReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var ComplexProductLink
+     */
+    private $complexProductLink;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var string
+     */
+    private $linkType;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param ComplexProductLink $complexProductLink
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param StoreManagerInterface $storeManager
+     * @param PriceBuilder $priceBuilder
+     * @param LoggerInterface $logger
+     * @param string $linkType
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        ComplexProductLink $complexProductLink,
+        EventKeyGenerator $eventKeyGenerator,
+        StoreManagerInterface $storeManager,
+        PriceBuilder $priceBuilder,
+        LoggerInterface $logger,
+        string $linkType
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->complexProductLink = $complexProductLink;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->storeManager = $storeManager;
+        $this->priceBuilder = $priceBuilder;
+        $this->logger = $logger;
+        $this->linkType = $linkType;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(array $indexData): \Generator
+    {
+        try {
+            foreach (\array_chunk($indexData, self::BATCH_SIZE) as $indexDataChunk) {
+                $result = [];
+                $parentIds = [];
+                $variationIds = [];
+
+                foreach ($indexDataChunk as $key => $data) {
+                    if (null === $data['parent_id']) {
+                        unset($indexDataChunk[$key]);
+                        continue;
+                    }
+
+                    $parentIds[] = $data['parent_id'];
+                    $variationIds[] = $data['entity_id'];
+                }
+
+                $select = $this->complexProductLink->getQuery($parentIds, $variationIds);
+                $cursor = $this->resourceConnection->getConnection()->query($select);
+
+                while ($row = $cursor->fetch()) {
+                    $result[$row['parent_id']][] = $row['variation_id'];
+                }
+
+                yield $this->getEventData($indexDataChunk, $result);
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve complex product link data.');
+        }
+    }
+
+    /**
+     * Retrieve prices event data
+     *
+     * @param array $indexData
+     * @param array $actualData
+     *
+     * @return array
+     *
+     * @throws LocalizedException
+     */
+    private function getEventData(array $indexData, array $actualData): array
+    {
+        $events = [];
+        $linkType = $this->linkType;
+        foreach ($indexData as $data) {
+            $actualVariations = $actualData[$data['parent_id']] ?? [];
+            $eventType = \in_array($data['entity_id'], $actualVariations) ? self::EVENT_VARIATION_CHANGED
+                : self::EVENT_VARIATION_DELETED;
+            $websiteId = (string)$this->storeManager->getWebsite(WebsiteInterface::ADMIN_CODE)->getWebsiteId();
+            $key = $this->eventKeyGenerator->generate($eventType, $websiteId, null);
+            $events[$key][] = $this->priceBuilder->buildComplexProductEventData(
+                $data['parent_id'],
+                $data['entity_id'],
+                $linkType
+            );
+        }
+
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/CustomOptionPriceEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/CustomOptionPriceEvent.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\PartialReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\CustomOptionPrice;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing custom option price events
+ */
+class CustomOptionPriceEvent implements PartialReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var CustomOptionPrice
+     */
+    private $customOptionPrice;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param CustomOptionPrice $customOptionPrice
+     * @param StoreManagerInterface $storeManager
+     * @param PriceBuilder $priceBuilder
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        CustomOptionPrice $customOptionPrice,
+        StoreManagerInterface $storeManager,
+        PriceBuilder $priceBuilder,
+        EventKeyGenerator $eventKeyGenerator,
+        LoggerInterface $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->customOptionPrice = $customOptionPrice;
+        $this->storeManager = $storeManager;
+        $this->priceBuilder = $priceBuilder;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(array $indexData): \Generator
+    {
+        try {
+            foreach (\array_chunk($indexData, self::BATCH_SIZE) as $indexDataChunk) {
+                $result = [];
+                $queryArguments = $this->buildQueryArguments($indexDataChunk);
+                foreach ($queryArguments as $scopeId => $optionIds) {
+                    $select = $this->customOptionPrice->getQuery(
+                        $optionIds,
+                        $scopeId
+                    );
+                    $cursor = $this->resourceConnection->getConnection()->query($select);
+                    while ($row = $cursor->fetch()) {
+                        $result[$scopeId][$row['option_id']] = [
+                            'option_id' => $row['option_id'],
+                            'price' => $row['price'],
+                            'price_type' => $row['price_type'],
+                        ];
+                    }
+                }
+                yield $this->getEventData($result);
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve product custom options price data.');
+        }
+    }
+
+    /**
+     * Build query arguments from index data or no data in case of full sync
+     *
+     * @param array $indexData
+     *
+     * @return array
+     */
+    private function buildQueryArguments(array $indexData): array
+    {
+        $queryArguments = [];
+        foreach ($indexData as $data) {
+            $queryArguments[$data['scope_id']][] = $data['entity_id'];
+        }
+        return $queryArguments;
+    }
+
+    /**
+     * Retrieve prices event data
+     *
+     * @param array $resultData
+     *
+     * @return array
+     *
+     * @throws NoSuchEntityException
+     * @throws \InvalidArgumentException
+     */
+    private function getEventData(array $resultData): array
+    {
+        $events = [];
+        foreach ($resultData as $scopeId => $pricesData) {
+            foreach ($pricesData as $priceData) {
+                $websiteId = (string)$this->storeManager->getStore($scopeId)->getWebsiteId();
+                $key = $this->eventKeyGenerator->generate(self::EVENT_CUSTOM_OPTION_PRICE_CHANGED, $websiteId, null);
+                $events[$key][] = $this->indexerPriceBuilder->buildCustomOptionPriceEventData($priceData);
+            }
+        }
+
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/CustomOptionTypePriceEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/CustomOptionTypePriceEvent.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\PartialReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\CustomOptionTypePrice;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing custom selectable option price events
+ */
+class CustomOptionTypePriceEvent implements PartialReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var CustomOptionTypePrice
+     */
+    private $customOptionTypePrice;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param CustomOptionTypePrice $customOptionTypePrice
+     * @param StoreManagerInterface $storeManager
+     * @param PriceBuilder $priceBuilder
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        CustomOptionTypePrice $customOptionTypePrice,
+        StoreManagerInterface $storeManager,
+        PriceBuilder $priceBuilder,
+        EventKeyGenerator $eventKeyGenerator,
+        LoggerInterface $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->customOptionTypePrice = $customOptionTypePrice;
+        $this->storeManager = $storeManager;
+        $this->priceBuilder = $priceBuilder;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(array $indexData): \Generator
+    {
+        try {
+            foreach (\array_chunk($indexData, self::BATCH_SIZE) as $indexDataChunk) {
+                $result = [];
+                $queryArguments = $this->buildQueryArguments($indexDataChunk);
+                foreach ($queryArguments as $scopeId => $optionTypeIds) {
+                    $select = $this->customOptionTypePrice->getQuery($optionTypeIds, $scopeId);
+                    $cursor = $this->resourceConnection->getConnection()->query($select);
+                    while ($row = $cursor->fetch()) {
+                        $result[$scopeId][$row['option_type_id']] = [
+                            'option_id' => $row['option_id'],
+                            'option_type_id' => $row['option_type_id'],
+                            'price' => $row['price'],
+                            'price_type' => $row['price_type'],
+                        ];
+                    }
+                }
+                yield $this->getEventsData($result);
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve product custom option types price data.');
+        }
+    }
+
+    /**
+     * Build query arguments from index data or no data in case of full sync
+     *
+     * @param array $indexData
+     *
+     * @return array
+     */
+    private function buildQueryArguments(array $indexData): array
+    {
+        $queryArguments = [];
+        foreach ($indexData as $data) {
+            $queryArguments[$data['scope_id']][] = $data['entity_id'];
+        }
+        return $queryArguments;
+    }
+
+    /**
+     * Retrieve prices event data
+     *
+     * @param array $resultData
+     *
+     * @return array
+     *
+     * @throws NoSuchEntityException
+     * @throws \InvalidArgumentException
+     */
+    private function getEventsData(array $resultData): array
+    {
+        $events = [];
+
+        foreach ($resultData as $scopeId => $data) {
+            foreach ($data as $priceData) {
+                $websiteId = (string)$this->storeManager->getStore($scopeId)->getWebsiteId();
+                $key = $this->eventKeyGenerator->generate(
+                    self::EVENT_CUSTOM_OPTION_TYPE_PRICE_CHANGED,
+                    $websiteId,
+                    null
+                );
+                $events[$key][] = $this->priceBuilder->buildCustomOptionTypePriceEventData($priceData);
+            }
+        }
+
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/DownloadableLinkPriceEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/DownloadableLinkPriceEvent.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\PartialReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\DownloadableLinkPrice;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing downloadable product link price events
+ */
+class DownloadableLinkPriceEvent implements PartialReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var DownloadableLinkPrice
+     */
+    private $downloadableLinkPrice;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param DownloadableLinkPrice $downloadableLinkPrice
+     * @param StoreManagerInterface $storeManager
+     * @param PriceBuilder $priceBuilder
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        DownloadableLinkPrice $downloadableLinkPrice,
+        StoreManagerInterface $storeManager,
+        PriceBuilder $priceBuilder,
+        EventKeyGenerator $eventKeyGenerator,
+        LoggerInterface $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->downloadableLinkPrice = $downloadableLinkPrice;
+        $this->storeManager = $storeManager;
+        $this->priceBuilder = $priceBuilder;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(array $indexData): \Generator
+    {
+        try {
+            foreach (\array_chunk($indexData, self::BATCH_SIZE) as $indexDataChunk) {
+                $result = [];
+                $queryArguments = [];
+
+                foreach ($indexDataChunk as $data) {
+                    $queryArguments[$data['scope_id']][] = $data['entity_id'];
+                }
+
+                foreach ($queryArguments as $scopeId => $ids) {
+                    $select = $this->downloadableLinkPrice->getQuery($ids, $scopeId);
+                    $cursor = $this->resourceConnection->getConnection()->query($select);
+
+                    while ($row = $cursor->fetch()) {
+                        $result[$row['entity_id']][$scopeId] = $row['value'];
+                    }
+                }
+
+                yield $this->getEventsData($indexDataChunk, $result);
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve downloadable link price data.');
+        }
+    }
+
+    /**
+     * Retrieve prices event data
+     *
+     * @param array $indexData
+     * @param array $actualData
+     *
+     * @return array
+     *
+     * @throws LocalizedException
+     * @throws \InvalidArgumentException
+     */
+    private function getEventsData(array $indexData, array $actualData): array
+    {
+        $events = [];
+
+        foreach ($indexData as $data) {
+            $value = $actualData[$data['entity_id']][$data['scope_id']] ?? null;
+            $eventType = null === $value ? self::EVENT_DOWNLOADABLE_LINK_PRICE_DELETED :
+                self::EVENT_DOWNLOADABLE_LINK_PRICE_CHANGED;
+            $websiteId = (string)$this->storeManager->getStore($data['scope_id'])->getWebsiteId();
+            $key = $this->eventKeyGenerator->generate($eventType, $websiteId, null);
+            $events[$key][] = $this->priceBuilder->buildDownloadableLinkPriceEventData($data['entity_id'], $value);
+        }
+
+        return $events;
+    }
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/PartialReindexPriceProviderInterface.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/PartialReindexPriceProviderInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\PartialReindex;
+
+use Magento\CatalogPriceDataExporter\Model\Provider\ProductPriceProviderInterface;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+
+/**
+ * Interface for product price events providers for partial indexation
+ */
+interface PartialReindexPriceProviderInterface extends ProductPriceProviderInterface
+{
+
+    /**
+     * Retrieve product price event data.
+     *
+     * @param array $indexData
+     *
+     * @return \Generator
+     *
+     * @throws UnableRetrieveData
+     */
+    public function retrieve(array $indexData): \Generator;
+}

--- a/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/TierPriceEvent.php
+++ b/app/code/Magento/CatalogPriceDataExporter/Model/Provider/PartialReindex/TierPriceEvent.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogPriceDataExporter\Model\Provider\PartialReindex;
+
+use Magento\CatalogPriceDataExporter\Model\EventKeyGenerator;
+use Magento\CatalogPriceDataExporter\Model\Indexer\PriceBuilder;
+use Magento\CatalogPriceDataExporter\Model\Query\TierPrice;
+use Magento\DataExporter\Exception\UnableRetrieveData;
+use Magento\Framework\App\ResourceConnection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class responsible for providing product tier prices events
+ */
+class TierPriceEvent implements PartialReindexPriceProviderInterface
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var TierPrice
+     */
+    private $tierPrice;
+
+    /**
+     * @var EventKeyGenerator
+     */
+    private $eventKeyGenerator;
+
+    /**
+     * @var PriceBuilder
+     */
+    private $priceBuilder;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param TierPrice $tierPrice
+     * @param EventKeyGenerator $eventKeyGenerator
+     * @param PriceBuilder $priceBuilder
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        TierPrice $tierPrice,
+        EventKeyGenerator $eventKeyGenerator,
+        PriceBuilder $priceBuilder,
+        LoggerInterface $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->tierPrice = $tierPrice;
+        $this->eventKeyGenerator = $eventKeyGenerator;
+        $this->priceBuilder = $priceBuilder;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function retrieve(array $indexData): \Generator
+    {
+        try {
+            foreach (\array_chunk($indexData, self::BATCH_SIZE) as $indexDataChunk) {
+                $result = [];
+                $queryArguments = [];
+                foreach ($indexDataChunk as $data) {
+                    $queryArguments[$data['scope_id']][] = $data['entity_id'];
+                }
+                foreach ($queryArguments as $scopeId => $entityIds) {
+                    $select = $this->tierPrice->getQuery($entityIds, $scopeId);
+                    $cursor = $this->resourceConnection->getConnection()->query($select);
+
+                    while ($row = $cursor->fetch()) {
+                        $result[$row['scope_id']][$row['customer_group_id']][$row['entity_id']][$row['qty']] = $row;
+                    }
+                }
+                yield $this->getEventData($indexDataChunk, $result);
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+            throw new UnableRetrieveData('Unable to retrieve product tier price data.');
+        }
+    }
+
+    /**
+     * Retrieve prices event data
+     *
+     * @param array $indexData
+     * @param array $actualData
+     *
+     * @return array
+     */
+    private function getEventData(array $indexData, array $actualData): array
+    {
+        $events = [];
+
+        foreach ($indexData as $data) {
+            $row = $actualData[$data['scope_id']][$data['customer_group']][$data['entity_id']][$data['qty']] ?? null;
+            $eventType = $this->resolveEventType($data['qty'], $row);
+
+            $key = $this->eventKeyGenerator->generate($eventType, $data['scope_id'], $data['customer_group']);
+            $priceType = $data['group_price_type'] ?? null;
+            $priceValue = $data['value'] ?? null;
+            $events[$key][] = $this->priceBuilder->buildTierPriceEventData(
+                (string)$indexData['entity_id'],
+                $indexData['qty'],
+                $priceType,
+                $priceValue
+            );
+        }
+
+        return $events;
+    }
+
+    /**
+     * Resolve event type
+     *
+     * @param string $qty
+     * @param array|null $data
+     *
+     * @return string
+     */
+    private function resolveEventType(string $qty, ?array $data): string
+    {
+        if ($qty > 1) {
+            return $data === null ? self::EVENT_TIER_PRICE_DELETED : self::EVENT_TIER_PRICE_CHANGED;
+        }
+        return $data === null ? self::EVENT_PRICE_DELETED : self::EVENT_PRICE_CHANGED;
+    }
+}


### PR DESCRIPTION
### Description (*)
This PR fixed the duplicate code from the PR, https://github.com/magento/commerce-data-export/pull/21/files#diff-ba1939c8004a571b5cb8c76346ab6b6a96427eb9ae468b637174954c486a83f8

### Related Pull Requests
 
https://github.com/magento/commerce-data-export/pull/21

### Fixed Issues (if relevant)

Fixed price event data providers contain some duplicate code. Specifically buildEventData functions in FullReindex and PartialReindex providers.
For example
\Magento\CatalogPriceDataExporter\Model\Provider\FullReindex\CustomOptionPriceEvent::buildEventData
and
\Magento\CatalogPriceDataExporter\Model\Provider\PartialReindex\CustomOptionPriceEvent::buildEventData
are the same.
